### PR TITLE
Cadence HiFi4 NN Library: Fixed maxpool

### DIFF
--- a/xa_nnlib/algo/kernels/pool/hifi4/xa_nn_maxpool_asym8.c
+++ b/xa_nnlib/algo/kernels/pool/hifi4/xa_nn_maxpool_asym8.c
@@ -137,7 +137,6 @@ static void maxpool_asym8_hw(
             loop_count = input_width - loop_count;
 
             align_dst = AE_ZALIGN64();
-            align_src1 = AE_LA64_PP(p_src1_temp);
 
             for(i = 0; i < (loop_count >> 2); i++)
             {

--- a/xa_nnlib/algo/kernels/pool/hifi4/xa_nn_maxpool_f32.c
+++ b/xa_nnlib/algo/kernels/pool/hifi4/xa_nn_maxpool_f32.c
@@ -322,8 +322,8 @@ const   FLOAT32* __restrict__ p_inp,
     XA_NNLIB_ARG_CHK_PTR(p_inp, -1);
     XA_NNLIB_ARG_CHK_PTR(p_scratch, -1);
     /* Pointer alignment checks */
-    XA_NNLIB_ARG_CHK_ALIGN(p_out, ALIGNMENT, -1);
-    XA_NNLIB_ARG_CHK_ALIGN(p_inp, ALIGNMENT, -1);
+    XA_NNLIB_ARG_CHK_ALIGN(p_out, sizeof(FLOAT32), -1);
+    XA_NNLIB_ARG_CHK_ALIGN(p_inp, sizeof(FLOAT32), -1);
     /* Basic Parameter checks */
     XA_NNLIB_ARG_CHK_COND((input_height <= 0 || input_width <= 0), -1);
     XA_NNLIB_ARG_CHK_COND((kernel_height > input_height), -1);


### PR DESCRIPTION
Integrated fixes related to xa_nn_maxpool_asym8 and xa_nn_maxpool_f32 functions.